### PR TITLE
fix: cutout shape for bottom nav bar

### DIFF
--- a/app/src/main/java/com/example/foodpack/ui/theme/Components.kt
+++ b/app/src/main/java/com/example/foodpack/ui/theme/Components.kt
@@ -47,8 +47,8 @@ class BottomAppBarCutoutShape(
                 centerX, notchDepth
             )
             cubicTo(
-                centerX - notchRadius * 0.66f, notchDepth,
-                centerX - notchRadius * 0.66f, 0f,
+                centerX + notchRadius * 0.66f, notchDepth,
+                centerX + notchRadius * 0.66f, 0f,
                 centerX + notchRadius, 0f
             )
 


### PR DESCRIPTION
The bottom app bar now have a better cutout shape